### PR TITLE
fix(weekly): fetch team totals after projections load

### DIFF
--- a/src/hooks/useSleeper.js
+++ b/src/hooks/useSleeper.js
@@ -147,8 +147,9 @@ export const useSleeperProjections = ({
         projections: filteredProjections
       }
     },
-    staleTime: 60 * 60 * 1000, // 1 hour for projections
-    gcTime: 60 * 60 * 1000,
+    retry: 3,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false
   })
 }
@@ -263,7 +264,7 @@ export const useSleeperRostersWithProjections = (week) => {
         totalTeams: enhancedRosters.length
       }
     },
-    enabled: !!week && !!rosters && !!users && !!players,
+    enabled: !!week && !!rosters && !!users && !!players && !!projections,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false


### PR DESCRIPTION
There was a race condition where total points/projections would render before the API call returned, leading to projections showing only the actual points scored. This PR adds projections to the dependency list for roster totals, and adds up to 3 retries should the projection API timeout or fail.